### PR TITLE
Create a standard layout that allows for the standard Docusarus structure

### DIFF
--- a/src/components/gameScriptComponents/ScriptPage.tsx
+++ b/src/components/gameScriptComponents/ScriptPage.tsx
@@ -1,10 +1,18 @@
-import { ReactNode, MouseEventHandler, useState, Ref, useCallback, createContext, useContext, useEffect, useMemo } from 'react';
-import { GameScript, RichText, TextPiece } from './scriptTypes';
+import {
+  ReactNode,
+  MouseEventHandler,
+  useState,
+  Ref,
+  useCallback,
+  createContext,
+  useContext,
+  useEffect,
+} from 'react';
+import { RichText, TextPiece } from './scriptTypes';
 import scriptStyles from './script.module.css';
 import clsx from 'clsx';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 import { PopOver } from '../popper/popper';
-import { produce } from 'immer';
 import { Conversation, createIndex, Line, ScriptIndex } from './scriptIndex';
 
 // Utility functions

--- a/src/components/gameScriptComponents/ScriptPage.tsx
+++ b/src/components/gameScriptComponents/ScriptPage.tsx
@@ -79,7 +79,7 @@ function useScriptFont() {
 
 // React contexts
 
-const ScriptData = createContext<ScriptIndex | null>(null);
+export const ScriptData = createContext<ScriptIndex | null>(null);
 
 function useScriptData(): ScriptIndex | null {
   return useContext(ScriptData);
@@ -186,7 +186,7 @@ function ConversationElem({ conv }: { conv: Conversation }): ReactNode {
   </div>;
 }
 
-function ScriptLayout({ convs }: { convs: Conversation[] }): ReactNode {
+export function ScriptLayout({ convs }: { convs: Conversation[] }): ReactNode {
   const entryNodes = sortBy(objGroupBy(convs, a => a.parentRoom),
     ([room, _]) => room.num).map(([room, convs]) => {
       const nounElems = sortBy(objGroupBy(convs, a => a.parentNoun),
@@ -215,7 +215,7 @@ function ScriptLayout({ convs }: { convs: Conversation[] }): ReactNode {
   return <div className={scriptStyles.script} children={entryNodes} />
 }
 
-function RoleTable({ }): ReactNode {
+export function RoleTable({ }): ReactNode {
   const script = useContext(ScriptData);
   return <table className={scriptStyles.roleTable}>
     <thead>
@@ -242,7 +242,7 @@ export interface TocFocuses {
   readonly room_id?: string;
 };
 
-function TableOfContents({ focuses, onFocusClose, onRoleSelect, onRoomSelect }: {
+export function TableOfContents({ focuses, onFocusClose, onRoleSelect, onRoomSelect }: {
   focuses?: TocFocuses,
   onFocusClose?: (field: 'role_id' | 'room_id') => void,
   onRoleSelect?: (role_id: string) => void,
@@ -293,108 +293,7 @@ function TableOfContents({ focuses, onFocusClose, onRoleSelect, onRoomSelect }: 
   </div>;
 }
 
-interface ScriptPageEventHandlers {
+export interface ScriptPageEventHandlers {
   readonly onRoleSelect?: (role_id: string) => void;
   readonly onRoomSelect?: (room_id: string) => void;
-}
-
-export default function ScriptPage({ script, headerHeight, fragment, handlers }: {
-  script: GameScript,
-  headerHeight: number,
-  fragment?: string,
-  handlers?: ScriptPageEventHandlers
-}): ReactNode {
-  useEffect(() => {
-    if (!fragment) {
-      console.log("No fragment")
-      return;
-    }
-
-    const element = document.getElementById(fragment);
-    if (!element) {
-      return;
-    }
-    element?.scrollIntoView();
-  }, [fragment])
-  const [scriptState, setScriptState] = useState<ScriptPageState | null>({});
-  const onFocusClose = useCallback((field: 'role_id' | 'room_id') => {
-    switch (field) {
-      case 'role_id':
-        setScriptState(produce(draft => {
-          draft.focuses = draft.focuses || {};
-          draft.focuses.role_id = null;
-        }));
-        break;
-      case 'room_id':
-        setScriptState(produce(draft => {
-          draft.focuses = draft.focuses || {};
-          draft.focuses.room_id = null;
-        }));
-        break;
-    }
-  }, []);
-  const onRoleSelect = useCallback((role_id: string) => {
-    setScriptState(produce(draft => {
-      draft.focuses = draft.focuses || {};
-      draft.focuses.role_id = role_id;
-    }));
-  }, []);
-  const onRoomSelect = useCallback((room_id: string) => {
-    setScriptState(produce(draft => {
-      draft.focuses = draft.focuses || {};
-      draft.focuses.room_id = room_id;
-    }));
-  }, []);
-
-  const scriptIndex = useMemo(() => createIndex(script), [script]);
-
-  const conversations = useMemo(() => {
-    if (!script) {
-      return [];
-    }
-
-    let conversations = Object.values(scriptIndex.conversations);
-    if (scriptState.focuses?.room_id) {
-      conversations = conversations.filter(conv => {
-        return conv.parentRoom.id === scriptState.focuses.room_id;
-      });
-    }
-
-    if (scriptState.focuses?.role_id) {
-      conversations = conversations.filter(conv => {
-        return conv.containsRole(scriptState.focuses.role_id);
-      });
-    }
-    return conversations;
-  }, [script, scriptState]);
-
-  if (!script) {
-    return null;
-  }
-
-  const body = <ScriptLayout convs={conversations} />;
-
-  return <ScriptData.Provider value={scriptIndex}>
-    <div className={scriptStyles.scriptWindow}>
-      <div className={scriptStyles.scriptSidebar}>
-        <div className={scriptStyles.sideMenu} style={{
-          ['--header-height' as any]: `${headerHeight}px`,
-        }}>
-          <TableOfContents
-            focuses={scriptState.focuses || {}}
-            onFocusClose={onFocusClose}
-            onRoleSelect={onRoleSelect}
-            onRoomSelect={onRoomSelect}
-          />
-        </div>
-      </div>
-      <div className={scriptStyles.scriptMain}>
-        <div>
-          <h2>Roles</h2>
-          <RoleTable />
-        </div>
-        {body}
-      </div>
-    </div>
-  </ScriptData.Provider>
 }

--- a/src/components/pages/LICENSE
+++ b/src/components/pages/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+Copyright (c) Brian Chin.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/components/pages/Layout/Main/index.tsx
+++ b/src/components/pages/Layout/Main/index.tsx
@@ -1,7 +1,7 @@
 import clsx from "clsx";
 import { ReactNode } from "react";
 
-import styles from '@theme/DocRoot/Layout/Mainstyles.module.css';
+import styles from './styles.module.css';
 
 export interface Props {
   hasSidebar: boolean;

--- a/src/components/pages/Layout/Main/index.tsx
+++ b/src/components/pages/Layout/Main/index.tsx
@@ -1,0 +1,29 @@
+import clsx from "clsx";
+import { ReactNode } from "react";
+
+import styles from '@theme/DocRoot/Layout/Mainstyles.module.css';
+
+export interface Props {
+  hasSidebar: boolean;
+  isSidebarVisible: boolean;
+  children?: ReactNode;
+}
+
+export default function Main({ hasSidebar, isSidebarVisible, children }: Props): ReactNode {
+  return (
+    <main
+      className={clsx(
+        styles.docMainContainer,
+        (!isSidebarVisible || !hasSidebar) && styles.docMainContainerEnhanced,
+      )}>
+      <div
+        className={clsx(
+          'container padding-top--md padding-bottom--lg',
+          styles.docItemWrapper,
+          (!hasSidebar) && styles.docItemWrapperEnhanced,
+        )}>
+        {children}
+      </div>
+    </main>
+  )
+}

--- a/src/components/pages/Layout/Main/index.tsx
+++ b/src/components/pages/Layout/Main/index.tsx
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Brian Chin.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the src/components/pages directory of this source tree.
+ */
+
 import clsx from "clsx";
 import { ReactNode } from "react";
 

--- a/src/components/pages/Layout/Main/styles.module.css
+++ b/src/components/pages/Layout/Main/styles.module.css
@@ -1,8 +1,9 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Brian Chin.
  *
  * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * LICENSE file in the src/components/pages directory of this source tree.
  */
 
  .docMainContainer {

--- a/src/components/pages/Layout/Main/styles.module.css
+++ b/src/components/pages/Layout/Main/styles.module.css
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+ .docMainContainer {
+  display: flex;
+  width: 100%;
+}
+
+@media (min-width: 997px) {
+  .docMainContainer {
+    flex-grow: 1;
+    max-width: calc(100% - var(--doc-sidebar-width));
+  }
+
+  .docMainContainerEnhanced {
+    max-width: calc(100% - var(--doc-sidebar-hidden-width));
+  }
+
+  .docItemWrapperEnhanced {
+    max-width: calc(
+      var(--ifm-container-width) + var(--doc-sidebar-width)
+    ) !important;
+  }
+}

--- a/src/components/pages/Layout/Sidebar/index.tsx
+++ b/src/components/pages/Layout/Sidebar/index.tsx
@@ -1,4 +1,11 @@
-import { useLocation } from "@docusaurus/router";
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Brian Chin.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the src/components/pages directory of this source tree.
+ */
+
 import { ReactNode, useCallback, useState } from "react";
 import { prefersReducedMotion, ThemeClassNames } from "@docusaurus/theme-common";
 import clsx from "clsx";

--- a/src/components/pages/Layout/Sidebar/index.tsx
+++ b/src/components/pages/Layout/Sidebar/index.tsx
@@ -42,7 +42,7 @@ export default function LayoutSidebar({ children, isVisible, setVisible }: Props
         !isVisible && styles.docSidebarContainerHidden,
       )}
       onTransitionEnd={(e) => {
-        if (!e.currentTarget.classList.contains(styles.docSidebarContainer!)) {
+        if (!e.currentTarget.classList.contains(styles.docSidebarContainer)) {
           return;
         }
 

--- a/src/components/pages/Layout/Sidebar/index.tsx
+++ b/src/components/pages/Layout/Sidebar/index.tsx
@@ -3,7 +3,7 @@ import { ReactNode, useCallback, useState } from "react";
 import { prefersReducedMotion, ThemeClassNames } from "@docusaurus/theme-common";
 import clsx from "clsx";
 
-import styles from "@theme/DocRoot/Layout/Sidebar/styles.module.css";
+import styles from './styles.module.css'
 import ExpandButton from '@theme/DocRoot/Layout/Sidebar/ExpandButton';
 
 export interface Props {

--- a/src/components/pages/Layout/Sidebar/index.tsx
+++ b/src/components/pages/Layout/Sidebar/index.tsx
@@ -2,6 +2,7 @@ import { useLocation } from "@docusaurus/router";
 import { ReactNode, useCallback, useState } from "react";
 import { prefersReducedMotion, ThemeClassNames } from "@docusaurus/theme-common";
 import clsx from "clsx";
+import Sidebar from "../../Sidebar"
 
 import styles from './styles.module.css'
 import ExpandButton from '@theme/DocRoot/Layout/Sidebar/ExpandButton';
@@ -47,7 +48,11 @@ export default function LayoutSidebar({ children, isVisible, setVisible }: Props
           styles.sidebarViewport,
           hiddenSidebar && styles.sidebarViewportHidden,
         )}>
-        {children}
+        <Sidebar
+          onCollapse={toggleSidebar}
+          isVisible={isVisible}>
+          {children}
+        </Sidebar>
         {hiddenSidebar && <ExpandButton toggleSidebar={toggleSidebar} />}
       </div>
     </aside>

--- a/src/components/pages/Layout/Sidebar/index.tsx
+++ b/src/components/pages/Layout/Sidebar/index.tsx
@@ -13,8 +13,6 @@ export interface Props {
 }
 
 export default function LayoutSidebar({ children, isVisible, setVisible }: Props): ReactNode {
-  const { pathname } = useLocation();
-
   const [hiddenSidebar, setHiddenSidebar] = useState(false);
   const toggleSidebar = useCallback(() => {
     if (hiddenSidebar) {

--- a/src/components/pages/Layout/Sidebar/index.tsx
+++ b/src/components/pages/Layout/Sidebar/index.tsx
@@ -1,0 +1,57 @@
+import { useLocation } from "@docusaurus/router";
+import { ReactNode, useCallback, useState } from "react";
+import { prefersReducedMotion, ThemeClassNames } from "@docusaurus/theme-common";
+import clsx from "clsx";
+
+import styles from "@theme/DocRoot/Layout/Sidebar/styles.module.css";
+import ExpandButton from '@theme/DocRoot/Layout/Sidebar/ExpandButton';
+
+export interface Props {
+  children?: ReactNode;
+  isVisible: boolean;
+  setVisible: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export default function LayoutSidebar({ children, isVisible, setVisible }: Props): ReactNode {
+  const { pathname } = useLocation();
+
+  const [hiddenSidebar, setHiddenSidebar] = useState(false);
+  const toggleSidebar = useCallback(() => {
+    if (hiddenSidebar) {
+      setHiddenSidebar(false);
+    }
+    // onTransitionEnd won't fire when sidebar animation is disabled
+    // fixes https://github.com/facebook/docusaurus/issues/8918
+    if (!hiddenSidebar && prefersReducedMotion()) {
+      setHiddenSidebar(true);
+    }
+    setVisible((value) => !value);
+  }, [setVisible, hiddenSidebar]);
+
+  return (
+    <aside
+      className={clsx(
+        ThemeClassNames.docs.docSidebarContainer,
+        styles.docSidebarContainer,
+        !isVisible && styles.docSidebarContainerHidden,
+      )}
+      onTransitionEnd={(e) => {
+        if (!e.currentTarget.classList.contains(styles.docSidebarContainer!)) {
+          return;
+        }
+
+        if (!isVisible) {
+          setHiddenSidebar(true);
+        }
+      }}>
+      <div
+        className={clsx(
+          styles.sidebarViewport,
+          hiddenSidebar && styles.sidebarViewportHidden,
+        )}>
+        {children}
+        {hiddenSidebar && <ExpandButton toggleSidebar={toggleSidebar} />}
+      </div>
+    </aside>
+  );
+}

--- a/src/components/pages/Layout/Sidebar/styles.module.css
+++ b/src/components/pages/Layout/Sidebar/styles.module.css
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+ :root {
+  --doc-sidebar-width: 300px;
+  --doc-sidebar-hidden-width: 30px;
+}
+
+.docSidebarContainer {
+  display: none;
+}
+
+@media (min-width: 997px) {
+  .docSidebarContainer {
+    display: block;
+    width: var(--doc-sidebar-width);
+    margin-top: calc(-1 * var(--ifm-navbar-height));
+    border-right: 1px solid var(--ifm-toc-border-color);
+    will-change: width;
+    transition: width var(--ifm-transition-fast) ease;
+    clip-path: inset(0);
+  }
+
+  .docSidebarContainerHidden {
+    width: var(--doc-sidebar-hidden-width);
+    cursor: pointer;
+  }
+
+  .sidebarViewport {
+    top: 0;
+    position: sticky;
+    height: 100%;
+    max-height: 100vh;
+  }
+}

--- a/src/components/pages/Layout/Sidebar/styles.module.css
+++ b/src/components/pages/Layout/Sidebar/styles.module.css
@@ -1,8 +1,9 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Brian Chin.
  *
  * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * LICENSE file in the src/components/pages directory of this source tree.
  */
 
  :root {

--- a/src/components/pages/Layout/index.tsx
+++ b/src/components/pages/Layout/index.tsx
@@ -28,7 +28,7 @@ export interface Props {
 }
 
 export default function Layout({ sidebar, content }: Props): ReactNode {
-  const [sidebarVisible, setSidebarVisible] = useState(false);
+  const [sidebarVisible, setSidebarVisible] = useState(true);
   return (
     <div className={layoutStyles.docsWrapper}>
       <BackToTopButton />

--- a/src/components/pages/Layout/index.tsx
+++ b/src/components/pages/Layout/index.tsx
@@ -1,0 +1,45 @@
+// A basic layout component that allows for a header, footer, sidebar, and main content area.
+//
+// Much of this code is copied/adapted from the Docusaurus theme-classic package,
+// and the DocsLayout component in particular.
+
+import {
+  ReactNode,
+  useState,
+} from 'react';
+import BackToTopButton from '@theme/BackToTopButton';
+import LayoutSidebar from './Sidebar';
+
+// The following imports may not be part of the docusaurus public API. They
+// will need to be duplicated here before full publishing.
+//
+// The code is under the MIT license, which is compatible with the permissive
+// license of this project.
+import layoutStyles from '@theme/DocRoot/Layout/styles.module.css';
+
+export interface Props {
+  // The sidebar to display on the left side of the page. If not provided, the
+  // sidebar will not be displayed.
+  sidebar?: ReactNode;
+
+  // The main content of the page.
+  content: ReactNode;
+}
+
+export default function Layout({ sidebar, content }: Props): ReactNode {
+  const [sidebarVisible, setSidebarVisible] = useState(false);
+  return (
+    <div className={layoutStyles.docsWrapper}>
+      <BackToTopButton />
+      <div className={layoutStyles.docRoot}>
+        {sidebar && (
+          <LayoutSidebar
+            isVisible={sidebarVisible}
+            setVisible={setSidebarVisible}>
+            {sidebar}
+          </LayoutSidebar>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/pages/Layout/index.tsx
+++ b/src/components/pages/Layout/index.tsx
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Brian Chin.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the src/components/pages directory of this source tree.
+ */
+
 // A basic layout component that allows for a header, footer, sidebar, and main content area.
 //
 // Much of this code is copied/adapted from the Docusaurus theme-classic package,

--- a/src/components/pages/Layout/index.tsx
+++ b/src/components/pages/Layout/index.tsx
@@ -9,13 +9,14 @@ import {
 } from 'react';
 import BackToTopButton from '@theme/BackToTopButton';
 import LayoutSidebar from './Sidebar';
+import LayoutMain from './Main';
 
 // The following imports may not be part of the docusaurus public API. They
 // will need to be duplicated here before full publishing.
 //
 // The code is under the MIT license, which is compatible with the permissive
 // license of this project.
-import layoutStyles from '@theme/DocRoot/Layout/styles.module.css';
+import layoutStyles from './styles.module.css';
 
 export interface Props {
   // The sidebar to display on the left side of the page. If not provided, the
@@ -39,6 +40,11 @@ export default function Layout({ sidebar, content }: Props): ReactNode {
             {sidebar}
           </LayoutSidebar>
         )}
+        <LayoutMain
+          hasSidebar={!!sidebar}
+          isSidebarVisible={sidebarVisible}>
+          {content}
+        </LayoutMain>
       </div>
     </div>
   );

--- a/src/components/pages/Layout/styles.module.css
+++ b/src/components/pages/Layout/styles.module.css
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+ .docRoot {
+  display: flex;
+  width: 100%;
+}
+
+.docsWrapper {
+  display: flex;
+  flex: 1 0 auto;
+}

--- a/src/components/pages/Layout/styles.module.css
+++ b/src/components/pages/Layout/styles.module.css
@@ -1,8 +1,9 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Brian Chin.
  *
  * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * LICENSE file in the src/components/pages directory of this source tree.
  */
 
  .docRoot {

--- a/src/components/pages/Root/index.tsx
+++ b/src/components/pages/Root/index.tsx
@@ -1,0 +1,21 @@
+import { HtmlClassNameProvider, ThemeClassNames } from '@docusaurus/theme-common'
+import { ReactNode } from 'react';
+
+import clsx from 'clsx';
+import RootLayout from '../Layout';
+import Layout from '@theme/Layout';
+
+export interface Props {
+  sidebar?: ReactNode;
+  children: ReactNode;
+}
+
+export default function Root({ sidebar, children }): ReactNode {
+  return <HtmlClassNameProvider className={clsx(ThemeClassNames.page.docsDocPage)}>
+    <Layout>
+      <RootLayout
+        sidebar={sidebar}
+        content={children} />
+    </Layout>
+  </HtmlClassNameProvider>
+}

--- a/src/components/pages/Root/index.tsx
+++ b/src/components/pages/Root/index.tsx
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Brian Chin.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the src/components/pages directory of this source tree.
+ */
+
 import { HtmlClassNameProvider, ThemeClassNames } from '@docusaurus/theme-common'
 import { ReactNode } from 'react';
 

--- a/src/components/pages/Root/index.tsx
+++ b/src/components/pages/Root/index.tsx
@@ -7,7 +7,7 @@ import Layout from '@theme/Layout';
 
 export interface Props {
   sidebar?: ReactNode;
-  children: ReactNode;
+  children?: ReactNode;
 }
 
 export default function Root({ sidebar, children }): ReactNode {

--- a/src/components/pages/Sidebar/Desktop/index.tsx
+++ b/src/components/pages/Sidebar/Desktop/index.tsx
@@ -1,8 +1,9 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Brian Chin.
  *
  * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * LICENSE file in the src/components/pages directory of this source tree.
  */
 
 import React from 'react';

--- a/src/components/pages/Sidebar/Desktop/index.tsx
+++ b/src/components/pages/Sidebar/Desktop/index.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import clsx from 'clsx';
+import { useThemeConfig } from '@docusaurus/theme-common';
+import Logo from '@theme/Logo';
+import CollapseButton from '@theme/DocSidebar/Desktop/CollapseButton';
+import Props from '../props';
+
+import styles from './styles.module.css';
+
+function SidebarDesktop({ children, onCollapse, isVisible }: Props) {
+  const {
+    navbar: { hideOnScroll },
+    docs: {
+      sidebar: { hideable },
+    },
+  } = useThemeConfig();
+
+  return (
+    <div
+      className={clsx(
+        styles.sidebar,
+        hideOnScroll && styles.sidebarWithHideableNavbar,
+        (!isVisible) && styles.sidebarHidden,
+      )}>
+      {hideOnScroll && <Logo tabIndex={-1} className={styles.sidebarLogo} />}
+      {children}
+      {hideable && <CollapseButton onClick={onCollapse} />}
+    </div>
+  );
+}
+
+export default React.memo(SidebarDesktop);

--- a/src/components/pages/Sidebar/Desktop/styles.module.css
+++ b/src/components/pages/Sidebar/Desktop/styles.module.css
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+ @media (min-width: 997px) {
+  .sidebar {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    padding-top: var(--ifm-navbar-height);
+    width: var(--doc-sidebar-width);
+  }
+
+  .sidebarWithHideableNavbar {
+    padding-top: 0;
+  }
+
+  .sidebarHidden {
+    opacity: 0;
+    visibility: hidden;
+  }
+
+  .sidebarLogo {
+    display: flex !important;
+    align-items: center;
+    margin: 0 var(--ifm-navbar-padding-horizontal);
+    min-height: var(--ifm-navbar-height);
+    max-height: var(--ifm-navbar-height);
+    color: inherit !important;
+    text-decoration: none !important;
+  }
+
+  .sidebarLogo img {
+    margin-right: 0.5rem;
+    height: 2rem;
+  }
+}
+
+.sidebarLogo {
+  display: none;
+}

--- a/src/components/pages/Sidebar/Desktop/styles.module.css
+++ b/src/components/pages/Sidebar/Desktop/styles.module.css
@@ -1,8 +1,9 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Brian Chin.
  *
  * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * LICENSE file in the src/components/pages directory of this source tree.
  */
 
  @media (min-width: 997px) {

--- a/src/components/pages/Sidebar/Desktop/styles.module.css
+++ b/src/components/pages/Sidebar/Desktop/styles.module.css
@@ -12,6 +12,7 @@
     height: 100%;
     padding-top: var(--ifm-navbar-height);
     width: var(--doc-sidebar-width);
+    overflow: hidden;
   }
 
   .sidebarWithHideableNavbar {

--- a/src/components/pages/Sidebar/Mobile/index.tsx
+++ b/src/components/pages/Sidebar/Mobile/index.tsx
@@ -1,8 +1,9 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Brian Chin.
  *
  * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * LICENSE file in the src/components/pages directory of this source tree.
  */
 
 import React from 'react';

--- a/src/components/pages/Sidebar/Mobile/index.tsx
+++ b/src/components/pages/Sidebar/Mobile/index.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import clsx from 'clsx';
+import {
+  NavbarSecondaryMenuFiller,
+  type NavbarSecondaryMenuComponent,
+  ThemeClassNames,
+} from '@docusaurus/theme-common';
+import { useNavbarMobileSidebar } from '@docusaurus/theme-common/internal';
+import Props from '../props';
+
+// eslint-disable-next-line react/function-component-definition
+const DocSidebarMobileSecondaryMenu: NavbarSecondaryMenuComponent<Props> = ({
+  children,
+}) => {
+  const mobileSidebar = useNavbarMobileSidebar();
+  return (
+    <ul className={clsx(ThemeClassNames.docs.docSidebarMenu, 'menu__list')}>
+      {children}
+    </ul>
+  );
+};
+
+function DocSidebarMobile(props: Props) {
+  return (
+    <NavbarSecondaryMenuFiller
+      component={DocSidebarMobileSecondaryMenu}
+      props={props}
+    />
+  );
+}
+
+export default React.memo(DocSidebarMobile);

--- a/src/components/pages/Sidebar/index.tsx
+++ b/src/components/pages/Sidebar/index.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from "react";
+
+import { useWindowSize } from "@docusaurus/theme-common";
+import Props from "./props"
+import SidebarDesktop from "./Desktop";
+import SidebarMobile from "./Mobile";
+
+export default function Sidebar(props: Props): ReactNode {
+  const windowSize = useWindowSize();
+
+  // Desktop sidebar visible on hydration: need SSR rendering
+  const shouldRenderSidebarDesktop =
+    windowSize === 'desktop' || windowSize === 'ssr';
+
+  // Mobile sidebar not visible on hydration: can avoid SSR rendering
+  const shouldRenderSidebarMobile = windowSize === 'mobile';
+
+  return (
+    <>
+      {shouldRenderSidebarDesktop && <SidebarDesktop {...props} />}
+      {shouldRenderSidebarMobile && <SidebarMobile {...props} />}
+    </>
+  );
+}

--- a/src/components/pages/Sidebar/index.tsx
+++ b/src/components/pages/Sidebar/index.tsx
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Brian Chin.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the src/components/pages directory of this source tree.
+ */
+
 import { ReactNode } from "react";
 
 import { useWindowSize } from "@docusaurus/theme-common";

--- a/src/components/pages/Sidebar/props.ts
+++ b/src/components/pages/Sidebar/props.ts
@@ -1,0 +1,7 @@
+import { ReactNode } from "react";
+
+export default interface Props {
+  readonly children?: ReactNode;
+  readonly onCollapse: () => void;
+  readonly isVisible: boolean;
+}

--- a/src/components/pages/Sidebar/props.ts
+++ b/src/components/pages/Sidebar/props.ts
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Brian Chin.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the src/components/pages directory of this source tree.
+ */
+
 import { ReactNode } from "react";
 
 export default interface Props {

--- a/src/pages/script/index.tsx
+++ b/src/pages/script/index.tsx
@@ -40,7 +40,7 @@ function ScriptPage({ script, fragment }: {
     }
     element?.scrollIntoView();
   }, [fragment])
-  const [scriptState, setScriptState] = useState<ScriptPageState | null>({});
+  const [scriptState, setScriptState] = useState<ScriptPageState>({});
   const onFocusClose = useCallback((field: 'role_id' | 'room_id') => {
     switch (field) {
       case 'role_id':

--- a/src/pages/script/index.tsx
+++ b/src/pages/script/index.tsx
@@ -1,6 +1,5 @@
-import { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  ScriptPageEventHandlers,
   ScriptPageState,
   ScriptData,
   ScriptLayout,
@@ -13,10 +12,6 @@ import scriptSchema from './script.schema.json';
 import { GameScript } from '@site/src/components/gameScriptComponents/scriptTypes';
 import scriptData from '@site/static/script.json';
 import { useLocation } from '@docusaurus/router';
-import LayoutProvider from '@theme/Layout/Provider';
-import Navbar from '@theme/Navbar';
-import pageStyles from './page.module.css';
-import useIsBrowser from '@docusaurus/useIsBrowser';
 import { produce } from 'immer';
 import { createIndex } from '@site/src/components/gameScriptComponents/scriptIndex';
 
@@ -26,53 +21,6 @@ const ajv = new Ajv({
   }
 });
 const validate = ajv.compile(scriptSchema);
-
-function useElementSize(
-): [{ width: number, height: number } | null, (HTMLElement) => void] {
-  const isBrowser = useIsBrowser();
-  const observer = useRef<ResizeObserver>(null);
-  const [sizedElem, setSizedElem] = useState<HTMLElement>(null);
-  const [size, setSize] = useState(null);
-
-  useEffect(() => {
-    if (!isBrowser) {
-      return;
-    }
-    ResizeObserverEntry;
-
-    if (!observer.current) {
-      observer.current = new ResizeObserver((entries) => {
-        let width = 0;
-        let height = 0;
-        for (const entry of entries) {
-          // Get the writing mode of the element, to sort out
-          // whether width or height is the writing mode
-          const writingMode = window.getComputedStyle(entry.target).writingMode;
-          const isVertical = writingMode === 'vertical-rl' || writingMode === 'vertical-lr';
-
-          for (const borderBox of entry.borderBoxSize) {
-            const entryWidth = isVertical ? borderBox.blockSize : borderBox.inlineSize;
-            const entryHeight = isVertical ? borderBox.inlineSize : borderBox.blockSize;
-            width = Math.max(width, entryWidth);
-            height = Math.max(height, entryHeight);
-          }
-        }
-        setSize({ width, height });
-      });
-    }
-
-    if (!sizedElem) {
-      return;
-    }
-
-    observer.current.observe(sizedElem);
-    return () => {
-      observer.current.unobserve(sizedElem);
-    }
-  }, [isBrowser, sizedElem])
-  return [size, setSizedElem];
-}
-
 
 function ScriptPage({ script, fragment }: {
   script: GameScript,

--- a/src/pages/script/index.tsx
+++ b/src/pages/script/index.tsx
@@ -156,7 +156,7 @@ function ScriptPage({ script, fragment }: {
   );
 
   return <ScriptData.Provider value={scriptIndex}>
-    <PageRoot sidebar>
+    <PageRoot sidebar={sidebar}>
       <div>
         <h2>Roles</h2>
         <RoleTable />

--- a/src/pages/script/index.tsx
+++ b/src/pages/script/index.tsx
@@ -1,5 +1,13 @@
-import { ReactNode, useEffect, useRef, useState } from 'react';
-import ScriptPage from '@site/src/components/gameScriptComponents/ScriptPage';
+import { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ScriptPageEventHandlers,
+  ScriptPageState,
+  ScriptData,
+  ScriptLayout,
+  TableOfContents,
+  RoleTable,
+} from '@site/src/components/gameScriptComponents/ScriptPage';
+import PageRoot from '@site/src/components/pages/Root';
 import Ajv from 'ajv';
 import scriptSchema from './script.schema.json';
 import { GameScript } from '@site/src/components/gameScriptComponents/scriptTypes';
@@ -9,6 +17,8 @@ import LayoutProvider from '@theme/Layout/Provider';
 import Navbar from '@theme/Navbar';
 import pageStyles from './page.module.css';
 import useIsBrowser from '@docusaurus/useIsBrowser';
+import { produce } from 'immer';
+import { createIndex } from '@site/src/components/gameScriptComponents/scriptIndex';
 
 const ajv = new Ajv({
   formats: {
@@ -63,10 +73,102 @@ function useElementSize(
   return [size, setSizedElem];
 }
 
+
+function ScriptPage({ script, fragment }: {
+  script: GameScript,
+  fragment?: string,
+}): ReactNode {
+  useEffect(() => {
+    if (!fragment) {
+      console.log("No fragment")
+      return;
+    }
+
+    const element = document.getElementById(fragment);
+    if (!element) {
+      return;
+    }
+    element?.scrollIntoView();
+  }, [fragment])
+  const [scriptState, setScriptState] = useState<ScriptPageState | null>({});
+  const onFocusClose = useCallback((field: 'role_id' | 'room_id') => {
+    switch (field) {
+      case 'role_id':
+        setScriptState(produce(draft => {
+          draft.focuses = draft.focuses || {};
+          draft.focuses.role_id = null;
+        }));
+        break;
+      case 'room_id':
+        setScriptState(produce(draft => {
+          draft.focuses = draft.focuses || {};
+          draft.focuses.room_id = null;
+        }));
+        break;
+    }
+  }, []);
+  const onRoleSelect = useCallback((role_id: string) => {
+    setScriptState(produce(draft => {
+      draft.focuses = draft.focuses || {};
+      draft.focuses.role_id = role_id;
+    }));
+  }, []);
+  const onRoomSelect = useCallback((room_id: string) => {
+    setScriptState(produce(draft => {
+      draft.focuses = draft.focuses || {};
+      draft.focuses.room_id = room_id;
+    }));
+  }, []);
+
+  const scriptIndex = useMemo(() => createIndex(script), [script]);
+
+  const conversations = useMemo(() => {
+    if (!script) {
+      return [];
+    }
+
+    let conversations = Object.values(scriptIndex.conversations);
+    if (scriptState.focuses?.room_id) {
+      conversations = conversations.filter(conv => {
+        return conv.parentRoom.id === scriptState.focuses.room_id;
+      });
+    }
+
+    if (scriptState.focuses?.role_id) {
+      conversations = conversations.filter(conv => {
+        return conv.containsRole(scriptState.focuses.role_id);
+      });
+    }
+    return conversations;
+  }, [script, scriptState]);
+
+  if (!script) {
+    return null;
+  }
+
+  const sidebar = (
+    <TableOfContents
+      focuses={scriptState.focuses || {}}
+      onFocusClose={onFocusClose}
+      onRoleSelect={onRoleSelect}
+      onRoomSelect={onRoomSelect}
+    />
+  );
+
+  return <ScriptData.Provider value={scriptIndex}>
+    <PageRoot sidebar>
+      <div>
+        <h2>Roles</h2>
+        <RoleTable />
+      </div>
+      <ScriptLayout convs={conversations} />
+    </PageRoot>
+  </ScriptData.Provider>;
+}
+
 export default function Page({ }): ReactNode {
   // We represent the current state as a fragment of the URL.
   const location = useLocation();
-  const [headerSize, setHeaderRef] = useElementSize();
 
   let hash = null;
   if (location.hash) {
@@ -79,17 +181,9 @@ export default function Page({ }): ReactNode {
     console.error(validate.errors);
     throw new Error('Invalid script data');
   }
-  return (<LayoutProvider>
-    <div className={pageStyles.screen}>
-      <div className={pageStyles.navBar} ref={setHeaderRef}>
-        <Navbar />
-      </div>
-      <div className={pageStyles.main}>
-        <ScriptPage
-          script={scriptData as GameScript}
-          headerHeight={headerSize ? headerSize.height : 0}
-          fragment={hash} />
-      </div>
-    </div>
-  </LayoutProvider>)
+  return (
+    <ScriptPage
+      script={scriptData as GameScript}
+      fragment={hash} />
+  );
 }

--- a/src/pages/script/index.tsx
+++ b/src/pages/script/index.tsx
@@ -15,6 +15,8 @@ import { useLocation } from '@docusaurus/router';
 import { produce } from 'immer';
 import { createIndex } from '@site/src/components/gameScriptComponents/scriptIndex';
 
+import styles from './page.module.css';
+
 const ajv = new Ajv({
   formats: {
     'uint32': true,
@@ -95,12 +97,14 @@ function ScriptPage({ script, fragment }: {
   }
 
   const sidebar = (
-    <TableOfContents
-      focuses={scriptState.focuses || {}}
-      onFocusClose={onFocusClose}
-      onRoleSelect={onRoleSelect}
-      onRoomSelect={onRoomSelect}
-    />
+    <div className={styles.scrollPane}>
+      <TableOfContents
+        focuses={scriptState.focuses || {}}
+        onFocusClose={onFocusClose}
+        onRoleSelect={onRoleSelect}
+        onRoomSelect={onRoomSelect}
+      />
+    </div>
   );
 
   return <ScriptData.Provider value={scriptIndex}>

--- a/src/pages/script/page.module.css
+++ b/src/pages/script/page.module.css
@@ -8,14 +8,14 @@
   overflow: hidden;
 }
 
-.navBar {
-  flex: 0 0 content;
-  width: 100%;
-}
-
 .main {
   flex: 1;
   width: 100%;
   overflow-y: scroll;
   scrollbar-gutter: stable;
+}
+
+.scrollPane {
+  flex: 1 auto;
+  overflow-y: scroll;
 }


### PR DESCRIPTION
Both the docs and blog plugin for Docusaurus have.a similar layout for their contents, but each is customized to their particular use case. This extracts the general layout code from the DocsRoot and Layout classes to make for something that can be used for a standard two-pane page UI.

It also replaces the script UI with this new component to simplify its code